### PR TITLE
Fix typeerror

### DIFF
--- a/custom_components/xiaomi_vacuum/miio/device.py
+++ b/custom_components/xiaomi_vacuum/miio/device.py
@@ -216,7 +216,7 @@ class Device(metaclass=DeviceGroupMeta):
                 values.extend(self.send(get_property_method, properties_to_request))
             except DeviceException:
                 _LOGGER.error("Unable to request properties %s", properties_to_request)
-                values.append(["request-failed"] * max_properties)
+                #values.append(["request-failed"] * max_properties)
             if max_properties is None:
                 break
 


### PR DESCRIPTION
If vacuum is disconnected for any reason the syslog will have following error continually until it reconnects 
```
Traceback (most recent call last):
    await self.async_device_update()
    await task
  File "/usr/local/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
    state = self._vacuum.status()
    return self.get_properties_for_dataclass(DreameStatus)
    response = {
    prop["did"]: prop["value"] if prop["code"] == 0 else None
TypeError: list indices must be integers or slices, not str

```